### PR TITLE
configure.ac: Require gtk+-x11-3.0 via pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,8 +58,8 @@ AC_SUBST(LIBDIR)
 dnl ****************************************************************************
 dnl * GTK
 dnl ****************************************************************************
-gtk_version="gtk+-3.0"
-PKG_CHECK_MODULES(GTK, [gtk+-3.0	>= 3.0])
+gtk_version="gtk+-x11-3.0"
+PKG_CHECK_MODULES(GTK, [gtk+-x11-3.0	>= 3.0])
 
 AC_SUBST(GTK_CFLAGS)
 AC_SUBST(GTK_LIBS)


### PR DESCRIPTION
Change the required pkg-config module from gtk+-3.0 to gtk+-x11-3.0.
Technically this does not change linked libraries but it ensures that
GTK+ was built with X11 support. If GTK+ was built without X11 support
(e.g. pure Wayland build), the package will fail at configure stage
instead of failing to build with missing <gdk/gdkx.h> header.