### PR TITLE
Fix gtk-doc 1.31+ build failure

### DIFF
--- a/docs/keybinder-docs.sgml
+++ b/docs/keybinder-docs.sgml
@@ -21,14 +21,12 @@
         <xi:include href="xml/keybinder.xml"/>
 
   </chapter>
-  <chapter id="object-tree">
-    <title>Object Hierarchy</title>
-     <xi:include href="xml/tree_index.sgml"/>
-  </chapter>
+
   <index id="api-index-full">
     <title>API Index</title>
     <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
   </index>
+
   <index id="deprecated-api-index" role="deprecated">
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>


### PR DESCRIPTION
Since this library doesn't define any gobjects, the generated `docs/xml/object_index.sgml` is always empty, and `docs/xml/tree_index.sgml` is altogether absent with gtk-doc 1.31+.

Fix a possible doc build error by not including the `tree_index.sgml`.

See GitHub issue kupferlauncher/keybinder#16.